### PR TITLE
Persist trusted block trait and use BlockHeight type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ stdcode= "0.1.2"
 themelio-stf= "0.5"
 tmelcrypt= "0.1.0"
 melnet= "0.1.0"
+acidjson= "0.1.0"
 serde={ version = "1.0.126", features = ["derive"] }
 
 novasmt= "0.1.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ stdcode= "0.1.2"
 themelio-stf= "0.5"
 tmelcrypt= "0.1.0"
 melnet= "0.1.0"
-acidjson= "0.1.0"
+# acidjson= "0.1.0"
 serde={ version = "1.0.126", features = ["derive"] }
 
 novasmt= "0.1.9"

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,8 +1,4 @@
-use std::{
-    collections::BTreeMap,
-    net::SocketAddr,
-    sync::{Arc, Mutex},
-};
+use std::{collections::BTreeMap, net::SocketAddr};
 
 use melnet::MelnetError;
 use novasmt::{CompressedProof, Forest, FullProof, InMemoryBackend};
@@ -18,7 +14,7 @@ use crate::{InMemoryTrustStore, NodeRequest, StateSummary, Substate};
 pub type BlockHeight = u64;
 
 /// Standard interface for persisting a trusted block.
-pub trait TrustedBlockPersister {
+pub trait TrustStore {
     /// Store the latest trusted block in persistent storage
     fn set(&self, netid: NetID, height: BlockHeight, header_hash: HashVal);
     /// Get the latest trusted block from persistent storage if one exists.
@@ -30,17 +26,24 @@ pub trait TrustedBlockPersister {
 pub struct ValClient<T = InMemoryTrustStore> {
     netid: NetID,
     raw: NodeClient,
-    trusted_blocks: T,
+    trust_store: T,
 }
 
-impl<T: TrustedBlockPersister> ValClient<T> {
+impl ValClient<InMemoryTrustStore> {
+    /// Creates a new ValClient, hardcoding the default, in-memory trust store.
+    pub fn new(netid: NetID, remote: SocketAddr) -> Self {
+        Self::new_with_truststore(netid, remote, InMemoryTrustStore::new())
+    }
+}
+
+impl<T: TrustStore> ValClient<T> {
     /// Creates a new ValClient.
-    pub fn new(netid: NetID, remote: SocketAddr, trusted_blocks: T) -> Self {
+    pub fn new_with_truststore(netid: NetID, remote: SocketAddr, trust_store: T) -> Self {
         let raw = NodeClient::new(netid, remote);
         Self {
             netid,
             raw,
-            trusted_blocks,
+            trust_store,
         }
     }
 
@@ -51,20 +54,24 @@ impl<T: TrustedBlockPersister> ValClient<T> {
 
     /// Trust a height.
     pub fn trust(&self, height: BlockHeight, header_hash: HashVal) {
-        let (t_height, t_head) = self.trusted_blocks.get(self.netid)
-            .map(|(cur_height, cur_head)|
+        let (t_height, t_head) = self
+            .trust_store
+            .get(self.netid)
+            .map(|(cur_height, cur_head)| {
                 if height > cur_height {
                     (height, header_hash)
                 } else {
                     (cur_height, cur_head)
-                })
+                }
+            })
             .or(Some((height, header_hash)))
             .expect("Trust should always return Some, this is a bug");
 
-        self.trusted_blocks.set(self.netid, t_height, t_head);
+        self.trust_store.set(self.netid, t_height, t_head);
     }
 
     /// Obtains the latest validated snapshot. Use this method first to get something to validate info against.
+    #[deprecated]
     pub async fn insecure_latest_snapshot(&self) -> melnet::Result<ValClientSnapshot> {
         self.trust_latest().await?;
         self.snapshot().await
@@ -107,6 +114,8 @@ impl<T: TrustedBlockPersister> ValClient<T> {
                 summary.height
             )));
         }
+        // automatically update trust
+        self.trust(summary.height, summary.header.hash());
         Ok(ValClientSnapshot {
             height: summary.height,
             header: summary.header,
@@ -116,8 +125,11 @@ impl<T: TrustedBlockPersister> ValClient<T> {
 
     /// Helper function to obtain the trusted staker set.
     async fn get_trusted_stakers(&self) -> melnet::Result<(BlockHeight, StakeMapping)> {
-        let (trusted_height, trusted_hash) = self.trusted_blocks.get(self.netid)
-            .ok_or(MelnetError::Custom("Expected to find a trusted block when fetching trusted stakers".into()))?;
+        let (trusted_height, trusted_hash) = self.trust_store.get(self.netid).ok_or_else(|| {
+            MelnetError::Custom(
+                "Expected to find a trusted block when fetching trusted stakers".into(),
+            )
+        })?;
 
         let temp_forest = Forest::new(InMemoryBackend::default());
         let stakers = self.raw.get_stakers_raw(trusted_height).await?;
@@ -325,7 +337,10 @@ impl NodeClient {
     }
 
     /// Gets an "abbreviated block".
-    pub async fn get_abbr_block(&self, height: BlockHeight) -> melnet::Result<(AbbrBlock, ConsensusProof)> {
+    pub async fn get_abbr_block(
+        &self,
+        height: BlockHeight,
+    ) -> melnet::Result<(AbbrBlock, ConsensusProof)> {
         get_abbr_block(self.clone(), height).await
     }
 
@@ -372,7 +387,10 @@ impl NodeClient {
     }
 
     /// Gets the stakers, **as the raw SMT mapping**
-    pub async fn get_stakers_raw(&self, height: BlockHeight) -> melnet::Result<BTreeMap<HashVal, Vec<u8>>> {
+    pub async fn get_stakers_raw(
+        &self,
+        height: BlockHeight,
+    ) -> melnet::Result<BTreeMap<HashVal, Vec<u8>>> {
         get_stakers_raw(self.clone(), height).await
     }
 }
@@ -422,6 +440,9 @@ async fn get_smt_branch(
 }
 
 #[cached::proc_macro::cached(result = true, size = 100)]
-async fn get_full_block(this: NodeClient, height: BlockHeight) -> melnet::Result<(Block, ConsensusProof)> {
+async fn get_full_block(
+    this: NodeClient,
+    height: BlockHeight,
+) -> melnet::Result<(Block, ConsensusProof)> {
     this.get_full_block(height, |_| None).await
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -13,7 +13,7 @@ use themelio_stf::{
 };
 use tmelcrypt::HashVal;
 
-use crate::{NodeRequest, StateSummary, Substate};
+use crate::{InMemoryTrustStore, NodeRequest, StateSummary, Substate};
 
 pub type BlockHeight = u64;
 
@@ -27,7 +27,7 @@ pub trait TrustedBlockPersister {
 
 /// A higher-level client that validates all information.
 #[derive(Debug, Clone)]
-pub struct ValClient<T> {
+pub struct ValClient<T = InMemoryTrustStore> {
     netid: NetID,
     raw: NodeClient,
     trusted_blocks: T,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,10 @@
 mod client;
 mod server;
+mod mem_trust_persister;
 
 pub use client::*;
 pub use server::*;
+pub use mem_trust_persister::*;
 
 use serde::{Deserialize, Serialize};
 use themelio_stf::{ConsensusProof, Header, NetID, Transaction, TxHash};

--- a/src/mem_trust_persister.rs
+++ b/src/mem_trust_persister.rs
@@ -1,39 +1,40 @@
-use tmelcrypt::HashVal;
-use acidjson::{AcidJson, AcidJsonError};
+use crate::{BlockHeight, TrustStore};
+use std::{collections::HashMap, sync::RwLock};
 use themelio_stf::NetID;
-use std::{collections::BTreeMap, path::Path};
-use crate::{BlockHeight, TrustedBlockPersister};
+use tmelcrypt::HashVal;
 
-/// File mapping from network id to latest trusted block.
-#[derive(Clone)]
-pub struct InMemoryTrustStore(AcidJson<BTreeMap<u8, (BlockHeight, HashVal)>>);
+/// In-memory trust store.
+pub struct InMemoryTrustStore {
+    inner: RwLock<HashMap<NetID, (BlockHeight, HashVal)>>,
+}
+
+impl Default for InMemoryTrustStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl InMemoryTrustStore {
-    /// Opens or creates a blockstore from a given filename.
-    pub fn open(path: &Path) -> Result<Self, AcidJsonError> {
-        // if not exists, create
-        if std::fs::read(path).is_err() {
-            std::fs::write(path, "{}")
-                .map_err(|e| AcidJsonError::IoError(e))?;
+    /// Creates a new in-memory trust store.
+    pub fn new() -> Self {
+        Self {
+            inner: Default::default(),
         }
-        Ok(Self( AcidJson::open(path)? ))
     }
 }
 
-impl TrustedBlockPersister for InMemoryTrustStore {
-    // Note: Allows a latest block to be rolled back to an earlier one
-    fn set(
-        &self,
-        netid: NetID,
-        height: BlockHeight,
-        header_hash: HashVal)
-    {
-        self.0.write().insert(netid as u8, (height, header_hash));
+impl TrustStore for InMemoryTrustStore {
+    fn set(&self, netid: NetID, height: BlockHeight, header_hash: HashVal) {
+        let mut inner = self.inner.write().unwrap();
+        if let Some((k, _)) = inner.get(&netid) {
+            if *k >= height {
+                return;
+            }
+        }
+        inner.insert(netid, (height, header_hash));
     }
 
-    fn get(&self, netid: NetID)
-    -> Option<(BlockHeight, HashVal)> {
-        self.0.read().get(&(netid as u8)).cloned()
+    fn get(&self, netid: NetID) -> Option<(BlockHeight, HashVal)> {
+        self.inner.read().unwrap().get(&netid).cloned()
     }
 }
-

--- a/src/mem_trust_persister.rs
+++ b/src/mem_trust_persister.rs
@@ -1,0 +1,39 @@
+use tmelcrypt::HashVal;
+use acidjson::{AcidJson, AcidJsonError};
+use themelio_stf::NetID;
+use std::{collections::BTreeMap, path::Path};
+use crate::{BlockHeight, TrustedBlockPersister};
+
+/// File mapping from network id to latest trusted block.
+#[derive(Clone)]
+pub struct InMemoryTrustStore(AcidJson<BTreeMap<u8, (BlockHeight, HashVal)>>);
+
+impl InMemoryTrustStore {
+    /// Opens or creates a blockstore from a given filename.
+    pub fn open(path: &Path) -> Result<Self, AcidJsonError> {
+        // if not exists, create
+        if std::fs::read(path).is_err() {
+            std::fs::write(path, "{}")
+                .map_err(|e| AcidJsonError::IoError(e))?;
+        }
+        Ok(Self( AcidJson::open(path)? ))
+    }
+}
+
+impl TrustedBlockPersister for InMemoryTrustStore {
+    // Note: Allows a latest block to be rolled back to an earlier one
+    fn set(
+        &self,
+        netid: NetID,
+        height: BlockHeight,
+        header_hash: HashVal)
+    {
+        self.0.write().insert(netid as u8, (height, header_hash));
+    }
+
+    fn get(&self, netid: NetID)
+    -> Option<(BlockHeight, HashVal)> {
+        self.0.read().get(&(netid as u8)).cloned()
+    }
+}
+


### PR DESCRIPTION
this PR changes the interface for `ValClient::new` to take a `trusted_blocks` persister.

A new release should follow this PR.